### PR TITLE
fix: estabiliza contrato da api e agregacoes

### DIFF
--- a/backend/src/main/java/br/com/smartTrafficFlow/Smart_Traffic_Flow/controller/TrafficController.java
+++ b/backend/src/main/java/br/com/smartTrafficFlow/Smart_Traffic_Flow/controller/TrafficController.java
@@ -1,8 +1,9 @@
 package br.com.smartTrafficFlow.Smart_Traffic_Flow.controller;
 
+import br.com.smartTrafficFlow.Smart_Traffic_Flow.dto.TrafficAggregationsResponse;
+import br.com.smartTrafficFlow.Smart_Traffic_Flow.dto.TrafficCreateRequest;
 import br.com.smartTrafficFlow.Smart_Traffic_Flow.dto.TrafficInsightsResponse;
 import br.com.smartTrafficFlow.Smart_Traffic_Flow.dto.TrafficResponse;
-import br.com.smartTrafficFlow.Smart_Traffic_Flow.entity.TrafficData;
 import br.com.smartTrafficFlow.Smart_Traffic_Flow.enums.Climate;
 import br.com.smartTrafficFlow.Smart_Traffic_Flow.service.SPTransService;
 import br.com.smartTrafficFlow.Smart_Traffic_Flow.service.TrafficService;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -71,12 +73,11 @@ public class TrafficController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "Registro criado com sucesso",
-                    content = @Content(schema = @Schema(implementation = TrafficData.class))),
+                    content = @Content(schema = @Schema(implementation = TrafficResponse.class))),
             @ApiResponse(responseCode = "400", description = "Payload invalido")
     })
-    public ResponseEntity<TrafficData> CreateTraffic(@RequestBody TrafficData data){
-        TrafficData salvo = service.save(data
-        );
+    public ResponseEntity<TrafficResponse> createTraffic(@Valid @RequestBody TrafficCreateRequest request){
+        TrafficResponse salvo = service.save(request);
         return new ResponseEntity<>(salvo, HttpStatus.CREATED);
     }
 
@@ -113,6 +114,20 @@ public class TrafficController {
     )
     public TrafficInsightsResponse getInsights() {
         return service.getInsights();
+    }
+
+    @GetMapping("/aggregations")
+    @Operation(
+            summary = "Retorna agregacoes do trafego",
+            description = "Calcula volume medio por horario e agrupamento por tipo de via para o MVP."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Agregacoes retornadas com sucesso",
+            content = @Content(schema = @Schema(implementation = TrafficAggregationsResponse.class))
+    )
+    public TrafficAggregationsResponse getAggregations() {
+        return service.getAggregations();
     }
 
     @GetMapping("/teste-sptrans")

--- a/backend/src/main/java/br/com/smartTrafficFlow/Smart_Traffic_Flow/service/TrafficService.java
+++ b/backend/src/main/java/br/com/smartTrafficFlow/Smart_Traffic_Flow/service/TrafficService.java
@@ -1,1 +1,197 @@
-package br.com.smartTrafficFlow.Smart_Traffic_Flow.service;import br.com.smartTrafficFlow.Smart_Traffic_Flow.dto.*;import br.com.smartTrafficFlow.Smart_Traffic_Flow.entity.TrafficData;import br.com.smartTrafficFlow.Smart_Traffic_Flow.enums.Climate;import br.com.smartTrafficFlow.Smart_Traffic_Flow.enums.TrafficAlert;import br.com.smartTrafficFlow.Smart_Traffic_Flow.repository.TrafficRepository;import com.fasterxml.jackson.core.type.TypeReference;import com.fasterxml.jackson.databind.ObjectMapper;import org.locationtech.jts.geom.Coordinate;import org.locationtech.jts.geom.GeometryFactory;import org.locationtech.jts.geom.Point;import org.springframework.stereotype.Service;import java.io.InputStream;import java.time.LocalDateTime;import java.util.List;import java.util.Map;import java.util.stream.Collectors;@Servicepublic class TrafficService {    private final TrafficRepository repository;    private final GeometryFactory geometryFactory = new GeometryFactory();    public TrafficService(TrafficRepository repository) {        this.repository = repository;    }    public List<TrafficDataDTO> loadFromJson(){        try {            ObjectMapper mapper = new ObjectMapper();            InputStream inputStream = getClass()                    .getClassLoader()                    .getResourceAsStream("traffic_data.json");            if (inputStream == null) {                throw new RuntimeException("Arquivo não encontrado");            }            return mapper.readValue(inputStream, new TypeReference<List<TrafficDataDTO>>() {}            );        } catch (Exception e) {            throw new RuntimeException("Erro ao carregar JSON", e);        }    }    public void loadData() {        List<TrafficDataDTO> dados = loadFromJson();        for (TrafficDataDTO dto : dados){            if (!repository.existsByIdviaAndHora(dto.getIdvia(), dto.getHora())){                TrafficData entity = new TrafficData();                //mapear os dados                entity.setIdvia(dto.getIdvia());                entity.setNome(dto.getNome());                entity.setTipo(dto.getTipo());                entity.setHora(dto.getHora());                entity.setClima(dto.getClima());                entity.setVolume(dto.getVolume());                entity.setCapacidade(dto.getCapacidade());                entity.setNivel(dto.getNivel());                entity.setStatus(dto.getStatus());                entity.setAlerta(dto.getAlerta());                //converter lat/lng -> Point (Geom)                if (dto.getLat() != null && dto.getLng() != null){                    Point point = geometryFactory.createPoint(                            new Coordinate(dto.getLng(), dto.getLat())                    );                    entity.setGeom(point);                }                repository.save(entity);            }        }    }    public List<TrafficResponse> getAll(){        return repository.findAll()                .stream()                .map(this::convertToResponse)                .toList();    }    public TrafficData save(TrafficData data){        return repository.save(data);    }    public List<TrafficResponse> findByFilters(            Climate clima,            Double nivel,            String alerta) {        List<TrafficData> resultado;        if (alerta != null && !alerta.trim().isEmpty()) {            try {                TrafficAlert alertaEnum =                        TrafficAlert.valueOf(alerta.toUpperCase());                resultado = repository.findByAlerta(alertaEnum);            } catch (IllegalArgumentException e) {                System.err.println("Aviso: alerta inválido");                resultado = repository.findAll();            }        } else if (clima != null && nivel != null) {            resultado =                    repository.findByClimaAndNivelGreaterThan(clima, nivel);        } else if (clima != null) {            resultado = repository.findByClima(clima);        } else if (nivel != null) {            resultado = repository.findByNivelGreaterThan(nivel);        } else {            resultado = repository.findAll();        }        return resultado.stream()                .map(this::convertToResponse)                .toList();    }    public TrafficInsightsResponse getInsights() {        List<TrafficData> trafficData = repository.findAll();        if (trafficData.isEmpty()) {            return new TrafficInsightsResponse(0, "N/D", 0, "N/D", 0.0);        }        Map< LocalDateTime, Integer> volumePorHora =                trafficData.stream()                        .collect(Collectors.groupingBy(                                TrafficData::getHora,                                Collectors.summingInt(TrafficData::getVolume)                        ));        Map<String, Double> mediaPorVia = trafficData.stream()                .collect(Collectors.groupingBy(TrafficData::getNome, Collectors.averagingInt(TrafficData::getVolume)));        Map.Entry<LocalDateTime, Integer> horarioPico =                volumePorHora.entrySet().stream()                        .max(Map.Entry.comparingByValue())                        .orElse(Map.entry(LocalDateTime.MIN, 0));        Map.Entry<String, Double> viaMaisMovimentada = mediaPorVia.entrySet().stream()                .max(Map.Entry.comparingByValue())                .orElse(Map.entry("N/D", 0.0));        return new TrafficInsightsResponse(                trafficData.size(),                horarioPico.getKey().toString(),                horarioPico.getValue(),                viaMaisMovimentada.getKey(),                viaMaisMovimentada.getValue()        );    }    private TrafficResponse convertToResponse(TrafficData data) {        return new TrafficResponse(                data.getId(),                data.getIdvia(),                data.getNome(),                data.getTipo(),                data.getHora(),                data.getClima(),                data.getVolume(),                data.getCapacidade(),                data.getNivel(),                data.getStatus(),                data.getAlerta(),                data.getLat(),                data.getLng()        );    }    public TrafficAggregationsResponse getAggregations(){        List<TrafficData> dados = repository.findAll();        //media volume por horario        var volumePorHorario = dados                .stream()                .collect(Collectors.groupingBy(                        d -> d.getHora().toLocalTime().toString(),                        Collectors.averagingInt(TrafficData::getVolume)                ))                .entrySet()                .stream()                .map(e -> new VolumePorHorarioDTO(                        e.getKey(),                        e.getValue()                ))                .sorted((a,b) -> a.hora().compareTo(b.hora()))                .toList();        //agrupar tipoo de via        var tipoVia =                dados.stream().collect(Collectors.groupingBy(                        TrafficData::getTipo))                        .entrySet()                        .stream()                        .map(entry -> {                            String tipo = entry.getKey().name();                            List<TrafficData> lista = entry.getValue();                            double media = lista.stream()                                    .collect(Collectors.averagingInt(TrafficData::getVolume));                            return new TipoViaDTO(                                    tipo,                                    (long) lista.size(),                                    media                            );                        })                        .toList();        return new TrafficAggregationsResponse(                volumePorHorario,                tipoVia        );    }}
+package br.com.smartTrafficFlow.Smart_Traffic_Flow.service;
+
+import br.com.smartTrafficFlow.Smart_Traffic_Flow.dto.TipoViaDTO;
+import br.com.smartTrafficFlow.Smart_Traffic_Flow.dto.TrafficAggregationsResponse;
+import br.com.smartTrafficFlow.Smart_Traffic_Flow.dto.TrafficCreateRequest;
+import br.com.smartTrafficFlow.Smart_Traffic_Flow.dto.TrafficDataDTO;
+import br.com.smartTrafficFlow.Smart_Traffic_Flow.dto.TrafficInsightsResponse;
+import br.com.smartTrafficFlow.Smart_Traffic_Flow.dto.TrafficMapper;
+import br.com.smartTrafficFlow.Smart_Traffic_Flow.dto.TrafficResponse;
+import br.com.smartTrafficFlow.Smart_Traffic_Flow.dto.VolumePorHorarioDTO;
+import br.com.smartTrafficFlow.Smart_Traffic_Flow.entity.TrafficData;
+import br.com.smartTrafficFlow.Smart_Traffic_Flow.enums.Climate;
+import br.com.smartTrafficFlow.Smart_Traffic_Flow.enums.TrafficAlert;
+import br.com.smartTrafficFlow.Smart_Traffic_Flow.exception.BadRequestException;
+import br.com.smartTrafficFlow.Smart_Traffic_Flow.repository.TrafficRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.stereotype.Service;
+
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class TrafficService {
+    private final TrafficRepository repository;
+    private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+    public TrafficService(TrafficRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<TrafficDataDTO> loadFromJson() {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+
+            InputStream inputStream = getClass()
+                    .getClassLoader()
+                    .getResourceAsStream("traffic_data.json");
+
+            if (inputStream == null) {
+                throw new RuntimeException("Arquivo nao encontrado");
+            }
+
+            return mapper.readValue(inputStream, new TypeReference<List<TrafficDataDTO>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("Erro ao carregar JSON", e);
+        }
+    }
+
+    public void loadData() {
+        List<TrafficDataDTO> dados = loadFromJson();
+
+        for (TrafficDataDTO dto : dados) {
+            if (!repository.existsByIdviaAndHora(dto.getIdvia(), dto.getHora())) {
+                TrafficData entity = new TrafficData();
+                entity.setIdvia(dto.getIdvia());
+                entity.setNome(dto.getNome());
+                entity.setTipo(dto.getTipo());
+                entity.setHora(dto.getHora());
+                entity.setClima(dto.getClima());
+                entity.setVolume(dto.getVolume());
+                entity.setCapacidade(dto.getCapacidade());
+                entity.setNivel(dto.getNivel());
+                entity.setStatus(dto.getStatus());
+                entity.setAlerta(dto.getAlerta());
+
+                if (dto.getLat() != null && dto.getLng() != null) {
+                    Point point = geometryFactory.createPoint(new Coordinate(dto.getLng(), dto.getLat()));
+                    point.setSRID(4326);
+                    entity.setGeom(point);
+                }
+
+                repository.save(entity);
+            }
+        }
+    }
+
+    public List<TrafficResponse> getAll() {
+        return repository.findAll()
+                .stream()
+                .map(TrafficMapper::toResponse)
+                .toList();
+    }
+
+    public TrafficResponse save(TrafficCreateRequest request) {
+        validateCoordinates(request.lat(), request.lng());
+        TrafficData entity = TrafficMapper.toEntity(request, geometryFactory);
+        TrafficData saved = repository.save(entity);
+        return TrafficMapper.toResponse(saved);
+    }
+
+    public List<TrafficResponse> findByFilters(Climate clima, Double nivel, String alerta) {
+        List<TrafficData> result;
+
+        if (alerta != null && !alerta.trim().isEmpty()) {
+            try {
+                TrafficAlert alertaEnum = TrafficAlert.valueOf(alerta.toUpperCase());
+                result = repository.findByAlerta(alertaEnum);
+            } catch (IllegalArgumentException e) {
+                throw new BadRequestException("alerta invalido");
+            }
+        } else if (clima != null && nivel != null) {
+            result = repository.findByClimaAndNivelGreaterThan(clima, nivel);
+        } else if (clima != null) {
+            result = repository.findByClima(clima);
+        } else if (nivel != null) {
+            result = repository.findByNivelGreaterThan(nivel);
+        } else {
+            result = repository.findAll();
+        }
+
+        return result.stream()
+                .map(TrafficMapper::toResponse)
+                .toList();
+    }
+
+    public TrafficInsightsResponse getInsights() {
+        List<TrafficData> trafficData = repository.findAll();
+        if (trafficData.isEmpty()) {
+            return new TrafficInsightsResponse(0, "N/D", 0, "N/D", 0.0);
+        }
+
+        Map<LocalDateTime, Integer> volumePorHora =
+                trafficData.stream()
+                        .collect(Collectors.groupingBy(
+                                TrafficData::getHora,
+                                Collectors.summingInt(TrafficData::getVolume)
+                        ));
+
+        Map<String, Double> mediaPorVia = trafficData.stream()
+                .collect(Collectors.groupingBy(
+                        TrafficData::getNome,
+                        Collectors.averagingInt(TrafficData::getVolume)
+                ));
+
+        Map.Entry<LocalDateTime, Integer> horarioPico =
+                volumePorHora.entrySet().stream()
+                        .max(Map.Entry.comparingByValue())
+                        .orElse(Map.entry(LocalDateTime.MIN, 0));
+
+        Map.Entry<String, Double> viaMaisMovimentada = mediaPorVia.entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .orElse(Map.entry("N/D", 0.0));
+
+        return new TrafficInsightsResponse(
+                trafficData.size(),
+                horarioPico.getKey().toString(),
+                horarioPico.getValue(),
+                viaMaisMovimentada.getKey(),
+                viaMaisMovimentada.getValue()
+        );
+    }
+
+    public TrafficAggregationsResponse getAggregations() {
+        List<TrafficData> dados = repository.findAll();
+
+        List<VolumePorHorarioDTO> volumePorHorario = dados.stream()
+                .collect(Collectors.groupingBy(
+                        d -> d.getHora().toLocalTime().toString(),
+                        Collectors.averagingInt(TrafficData::getVolume)
+                ))
+                .entrySet()
+                .stream()
+                .map(e -> new VolumePorHorarioDTO(e.getKey(), e.getValue()))
+                .sorted((a, b) -> a.hora().compareTo(b.hora()))
+                .toList();
+
+        List<TipoViaDTO> volumePorTipoVia = dados.stream()
+                .collect(Collectors.groupingBy(TrafficData::getTipo))
+                .entrySet()
+                .stream()
+                .map(entry -> {
+                    String tipo = entry.getKey().name();
+                    List<TrafficData> lista = entry.getValue();
+                    double media = lista.stream()
+                            .collect(Collectors.averagingInt(TrafficData::getVolume));
+
+                    return new TipoViaDTO(tipo, (long) lista.size(), media);
+                })
+                .toList();
+
+        return new TrafficAggregationsResponse(volumePorHorario, volumePorTipoVia);
+    }
+
+    private void validateCoordinates(Double lat, Double lng) {
+        if ((lat == null && lng != null) || (lat != null && lng == null)) {
+            throw new BadRequestException("lat e lng devem ser enviados juntos");
+        }
+    }
+}

--- a/backend/src/test/java/br/com/smartTrafficFlow/Smart_Traffic_Flow/controller/TrafficControllerIntegrationTest.java
+++ b/backend/src/test/java/br/com/smartTrafficFlow/Smart_Traffic_Flow/controller/TrafficControllerIntegrationTest.java
@@ -22,7 +22,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {
         "openweather.api.key=test-key",
-        "openweather.api.url=https://api.openweathermap.org/data/2.5/weather"
+        "openweather.api.url=https://api.openweathermap.org/data/2.5/weather",
+        "sptrans.token=test-token",
+        "sptrans.api.url=http://api.olhovivo.sptrans.com.br/v2.1"
 })
 class TrafficControllerIntegrationTest {
 

--- a/backend/src/test/java/br/com/smartTrafficFlow/Smart_Traffic_Flow/integration/TrafficAggregationTest.java
+++ b/backend/src/test/java/br/com/smartTrafficFlow/Smart_Traffic_Flow/integration/TrafficAggregationTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -13,6 +14,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "openweather.api.key=test-key",
+        "openweather.api.url=https://api.openweathermap.org/data/2.5/weather",
+        "sptrans.token=test-token",
+        "sptrans.api.url=http://api.olhovivo.sptrans.com.br/v2.1"
+})
 public class TrafficAggregationTest {
 
     @Autowired

--- a/docs/api.md
+++ b/docs/api.md
@@ -140,6 +140,35 @@ Exemplo:
 }
 ```
 
+### `GET /traffic/aggregations`
+
+Retorna agregações simples para o MVP com base nos registros persistidos.
+
+Resposta atual:
+
+- `volumePorHorario`: média de volume por horário
+- `volumePorTipoVia`: agrupamento por tipo de via com quantidade de registros e média de volume
+
+Exemplo:
+
+```json
+{
+  "volumePorHorario": [
+    {
+      "hora": "08:00",
+      "mediaVolume": 454.33
+    }
+  ],
+  "volumePorTipoVia": [
+    {
+      "tipoVia": "ARTERIAL",
+      "quantidade": 24,
+      "mediaVolume": 320.5
+    }
+  ]
+}
+```
+
 ## Fluxo de Consulta
 
 ```mermaid


### PR DESCRIPTION
## Objetivo

Esta branch foi criada a partir da `dev` com foco exclusivo em estabilização do backend principal da aplicação.

A intenção não é abrir escopo novo, e sim restaurar consistência da API, preservar o que já foi entregue e manter as agregações que entraram recentemente sem regressão do contrato principal.

## Escopo desta estabilização

- restaurar o contrato correto do `POST /traffic`
- reaplicar `TrafficCreateRequest`, `@Valid` e `TrafficResponse`
- restaurar a versão estável do `TrafficService`
- preservar a lógica útil de agregações da Task #44
- expor corretamente o endpoint `GET /traffic/aggregations`
- corrigir regressões no comportamento do filtro por alerta
- alinhar os testes de integração ao estado real da API
- alinhar `docs/api.md` ao contrato final estabilizado

## O que não entra neste PR

- login
- segurança/autenticação
- frontend
- novas integrações GTFS além do que já afeta diretamente o backend principal
- refatoração ampla fora do escopo de estabilização

## Resultado esperado

Ao final deste PR, a `dev` deve voltar a ficar com:

- contrato estável para os endpoints principais
- `POST /traffic` consistente com DTO e validação
- agregações disponíveis sem regressão do restante da API
- testes principais coerentes com o comportamento real
- documentação alinhada ao código atual